### PR TITLE
handle schema paths named parent

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ const plugin = function(schema, options) {
 
                                 model = this.model;
                             } else {
-                                const parentDoc = this.parent();
+                                const parentDoc = this.$parent();
                                 const isNew = parentDoc.isNew;
 
                                 if (!isNew && !parentDoc.isModified(pathName)) {


### PR DESCRIPTION
Re: Automattic/mongoose#14663

Mongoose documents have a `$parent()` function that's equivalent to `parent()`, which is helpful for cases where users have a schema path named `parent`. With this change, mongoose-unique-validator will work with paths named `parent`.